### PR TITLE
add ignoreRecentFlag option

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -23,6 +23,12 @@ password=test1234
 # default: INBOX
 folder=INBOX
 
+# ignore recent flag on new messages, enable this if the command is not executed when a new message is received
+# WARNING: the command will be executed when any message is added to the watched mailbox folder (for example: a deleted message moved back to the watched inbox folder)
+# possible values: "true", "false", "1", "0"
+# default: false
+ignore_recent_flag=false
+
 # whether to use encryption
 # possible values: "none", "ssl", "starttls"
 # default: none

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -128,4 +128,5 @@ def create_imap_idle_handler(
         connector=connector,
         callback=callback,
         folder=get_imap_folder(config=config, section=section),
+        ignoreRecentFlag=config.get(section, 'ignore_recent_flag', fallback='0').strip().lower() in ('1', 'true'),
     )


### PR DESCRIPTION
Some mail servers don't send RECENT flag in IDLE responses, causing the command to not get executed when a new message is received.

This PR adds an opt-in workaround that ignores RECENT flag, at the cost of being triggered by any mail appearing in the watched folder (deleted message moved back to inbox for example).